### PR TITLE
print() function and new style exceptions for Python 3

### DIFF
--- a/source/ftp_connector/ftp_conn.py
+++ b/source/ftp_connector/ftp_conn.py
@@ -293,7 +293,7 @@ class FtpConnector(TemplateConnection):
                 os.makedirs(dirname)
                 print("created {0}".format(dirname))
             except Exception as e:
-                print e
+                print(e)
                 self._make_parent_dir(dirname)
 
     def _download_ftp_file(self, ftp_handle, name, dest, overwrite):
@@ -313,7 +313,7 @@ class FtpConnector(TemplateConnection):
         """ replicates a directory on an ftp server recursively """
         for item in ftp_handle.nlst(name):
             if os.path.dirname(item) == '':
-                print os.path.dirname(item)
+                print(os.path.dirname(item))
                 item = name + '/' + item
             if self._is_ftp_dir(ftp_handle, item, guess_by_extension):
                 self._mirror_ftp_dir(ftp_handle, item, overwrite, guess_by_extension)
@@ -354,7 +354,7 @@ class FtpConnector(TemplateConnection):
         ftp = ftplib.FTP(self._server_name, self._userName, self._userPwd)
         if remote_dir == '/' or remote_dir == '':
             dir1 = ftp.nlst()
-            print ftp
+            print(ftp)
             for item in dir1:
                 try:
                     if type(ftp.size(item)) == int:
@@ -457,7 +457,7 @@ class FtpConnector(TemplateConnection):
             self.start_checkout(path)
         try:
             return tuple(os.lstat(self._fqn(path)))
-        except Exception, e:
+        except Exception as e:
             self._mylogger.info("FtpConnector.lstat(): Exception, %s on path=%s" % (e, path))
             raise IOError(e)
 
@@ -485,7 +485,7 @@ class FtpConnector(TemplateConnection):
         #self._mylogger.info('FtpConnector.create_file(): path=%s, size=%s, map=%s' % (path, str(size), str(attrMap)))
         try:
             fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDWR|os.O_CREAT))
-        except Exception, e:
+        except Exception as e:
             raise IOError(e)
 
         return fileHandle
@@ -499,7 +499,7 @@ class FtpConnector(TemplateConnection):
         try:
             self.lstat(requestPath)
             return True
-        except Exception, e:
+        except Exception as e:
             return False
 
     # ------------------------------------------------------------------------
@@ -510,7 +510,7 @@ class FtpConnector(TemplateConnection):
         #self._mylogger.info("FtpConnector._truncateFile(): path=%s" % path)
         try:
            return os.open(self._fqn(path), os.O_RDWR|os.O_TRUNC)
-        except Exception, e:
+        except Exception as e:
             #self._mylogger.info("FtpConnector._truncateFile(): Exception, %s on path=%s" % (e, path))
             raise IOError(e)
 
@@ -539,7 +539,7 @@ class FtpConnector(TemplateConnection):
                 try:
                     fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDONLY))
                     #self._mylogger.info("FtpConnector.open_file: The file, %s opened successfully." % (path))
-                except Exception, e:
+                except Exception as e:
                     #self._mylogger.info("FtpConnector.open_file: Error %s opening %s." % (e, path))
                     raise IOError(e)
         elif mode==TemplateConnection.FILE_WRITE:
@@ -547,13 +547,13 @@ class FtpConnector(TemplateConnection):
                 #self._mylogger.info("FtpConnector.open_file: File '%s' doesn't exist, create it." % (path))
                 try:
                     fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDWR|os.O_CREAT))
-                except Exception, e:
+                except Exception as e:
                     raise IOError(e)
             else:
                 #self._mylogger.info("FtpConnector.open_file: File '%s' exists, truncate it." % (path))
                 try:
                     fileHandle.setOsHandle(self._truncateFile(path))
-                except Exception, e:
+                except Exception as e:
                     raise IOError(e)
         else:
             #self._mylogger.info("FtpConnector.open_file:Open mode %s is not supported." % (mode))
@@ -583,7 +583,7 @@ class FtpConnector(TemplateConnection):
 
         try:
             w = os.write(fileHandle.getOsHandle(), filebuf)
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.write_file: Error %s on '%s'." % (e, path))
 
         # TODO: Should short writes be reported?
@@ -614,7 +614,7 @@ class FtpConnector(TemplateConnection):
             raise IOError("FtpConnector.read_file: File %s, not open." % (path))
         try:
             buf = os.read(fileHandle.getOsHandle(), readSize)
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.read_file: Error %s on '%s'." % (e, path))
 
         return buf
@@ -635,7 +635,7 @@ class FtpConnector(TemplateConnection):
         try:
             buf = os.close(fileHandle.getOsHandle())
             fileHandle.setOsHandle(None)
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.close: Error %s." % (e))
         return {}
 
@@ -663,7 +663,7 @@ class FtpConnector(TemplateConnection):
         #self._mylogger.info('FtpConnector.setTimestamps path: >%s< '  % (path))
         try:
             os.utime(self._fqn(path), (mtime, atime))
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.setTimestamps: Error's'" % (e))
 
         return True
@@ -677,7 +677,7 @@ class FtpConnector(TemplateConnection):
         #self._mylogger.info('FtpConnector.makedirs():  path->%s< ' % (path))
         try:
             os.makedirs(self._fqn(path))
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.makedirs: Error %s." % (e))
 
         return True
@@ -693,7 +693,7 @@ class FtpConnector(TemplateConnection):
             if not path.startswith('/'):
                 p = self._fqn(path)
             os.rmdir(p)
-        except Exception, e:
+        except Exception as e:
             raise IOError("FtpConnector.rmdir: Error %s." % (e))
         return True
 
@@ -708,7 +708,7 @@ class FtpConnector(TemplateConnection):
             if not path.startswith('/'):
                 p = self._fqn(path)
             os.unlink(p)
-        except Exception, e:
+        except Exception as e:
             #self._mylogger.info("FtpConnector.unlink(): Exception, %s on path=%s" % (e, path))
             raise IOError("FtpConnector.unlink: Error %s." % (e))
         return True
@@ -790,7 +790,7 @@ class FtpConnector(TemplateConnection):
         #self._mylogger.info('FtpConnector.verify_mount(): path=%s, includeDirs=%s' % (path, includeDirs))
         try:
             readable = self.is_dir(path)
-        except Exception, err:
+        except Exception as err:
             #self._mylogger.info("FtpConnector.verify_mount(): %s failed checking path. (%s)" % (path, err))
             errlist.append(str(err))
             verified = False
@@ -798,11 +798,11 @@ class FtpConnector(TemplateConnection):
         try:
             writeErrlist, writable, deleted = self._verify_write(path)
             errlist.extend(writeErrlist)
-        except Exception, err:
+        except Exception as err:
             #self._mylogger.info("FtpConnector.verify_mount(): %s failed verifying write. (%s)" % (path, err))
             errlist.append(str(err))
 
         return (verified, errlist, readable, writable)
 
 if __name__ == '__main__':
-    print 'sample_conn.main(): started'
+    print('sample_conn.main(): started')

--- a/source/svn_connector/svn_conn.py
+++ b/source/svn_connector/svn_conn.py
@@ -382,7 +382,7 @@ class SvnConnector(TemplateConnection):
         self._mylogger.info("SvnConnector.lstat(): path=%s, extras=%s" % (path, str(extras)))
         try:
             return tuple(os.lstat(self._fqn(path)))
-        except Exception, e:
+        except Exception as e:
             self._mylogger.info("SvnConnector.lstat(): Exception, %s on path=%s" % (e, path))
             raise IOError(e)
 
@@ -410,7 +410,7 @@ class SvnConnector(TemplateConnection):
         #self._mylogger.info('SvnConnector.create_file(): path=%s, size=%s, map=%s' % (path, str(size), str(attrMap)))
         try:
             fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDWR|os.O_CREAT))
-        except Exception, e:
+        except Exception as e:
             raise IOError(e)
 
         return fileHandle
@@ -424,7 +424,7 @@ class SvnConnector(TemplateConnection):
         try:
             self.lstat(requestPath)
             return True
-        except Exception, e:
+        except Exception as e:
             return False
 
     # ------------------------------------------------------------------------
@@ -435,7 +435,7 @@ class SvnConnector(TemplateConnection):
         #self._mylogger.info("SvnConnector._truncateFile(): path=%s" % path)
         try:
            return os.open(self._fqn(path), os.O_RDWR|os.O_TRUNC)
-        except Exception, e:
+        except Exception as e:
             #self._mylogger.info("SvnConnector._truncateFile(): Exception, %s on path=%s" % (e, path))
             raise IOError(e)
 
@@ -464,7 +464,7 @@ class SvnConnector(TemplateConnection):
                 try:
                     fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDONLY))
                     #self._mylogger.info("SvnConnector.open_file: The file, %s opened successfully." % (path))
-                except Exception, e:
+                except Exception as e:
                     #self._mylogger.info("SvnConnector.open_file: Error %s opening %s." % (e, path))
                     raise IOError(e)
         elif mode==TemplateConnection.FILE_WRITE:
@@ -472,13 +472,13 @@ class SvnConnector(TemplateConnection):
                 #self._mylogger.info("SvnConnector.open_file: File '%s' doesn't exist, create it." % (path))
                 try:
                     fileHandle.setOsHandle(os.open(self._fqn(path), os.O_RDWR|os.O_CREAT))
-                except Exception, e:
+                except Exception as e:
                     raise IOError(e)
             else:
                 #self._mylogger.info("SvnConnector.open_file: File '%s' exists, truncate it." % (path))
                 try:
                     fileHandle.setOsHandle(self._truncateFile(path))
-                except Exception, e:
+                except Exception as e:
                     raise IOError(e)
         else:
             #self._mylogger.info("SvnConnector.open_file:Open mode %s is not supported." % (mode))
@@ -508,7 +508,7 @@ class SvnConnector(TemplateConnection):
         
         try:
             w = os.write(fileHandle.getOsHandle(), filebuf)
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.write_file: Error %s on '%s'." % (e, path))
 
         # TODO: Should short writes be reported?
@@ -539,7 +539,7 @@ class SvnConnector(TemplateConnection):
             raise IOError("SvnConnector.read_file: File %s, not open." % (path))
         try:
             buf = os.read(fileHandle.getOsHandle(), readSize)
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.read_file: Error %s on '%s'." % (e, path))
 
         return buf
@@ -560,7 +560,7 @@ class SvnConnector(TemplateConnection):
         try:
             buf = os.close(fileHandle.getOsHandle())
             fileHandle.setOsHandle(None)
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.close: Error %s." % (e))
         return {}
 
@@ -588,7 +588,7 @@ class SvnConnector(TemplateConnection):
         #self._mylogger.info('SvnConnector.setTimestamps path: >%s< '  % (path))
         try:
             os.utime(self._fqn(path), (mtime, atime))
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.setTimestamps: Error's'" % (e))
 
         return True
@@ -602,7 +602,7 @@ class SvnConnector(TemplateConnection):
         #self._mylogger.info('SvnConnector.makedirs():  path->%s< ' % (path))
         try:
             os.makedirs(self._fqn(path))
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.makedirs: Error %s." % (e))
 
         return True
@@ -618,7 +618,7 @@ class SvnConnector(TemplateConnection):
             if not path.startswith('/'):
                 p = self._fqn(path)
             os.rmdir(p)
-        except Exception, e:
+        except Exception as e:
             raise IOError("SvnConnector.rmdir: Error %s." % (e))
         return True
 
@@ -633,7 +633,7 @@ class SvnConnector(TemplateConnection):
             if not path.startswith('/'):
                 p = self._fqn(path)
             os.unlink(p)
-        except Exception, e:
+        except Exception as e:
             #self._mylogger.info("SvnConnector.unlink(): Exception, %s on path=%s" % (e, path))
             raise IOError("SvnConnector.unlink: Error %s." % (e))
         return True
@@ -714,7 +714,7 @@ class SvnConnector(TemplateConnection):
         #self._mylogger.info('SvnConnector.verify_mount(): path=%s, includeDirs=%s' % (path, includeDirs))
         try:
             readable = self.is_dir(path)
-        except Exception, err:
+        except Exception as err:
             #self._mylogger.info("SvnConnector.verify_mount(): %s failed checking path. (%s)" % (path, err))
             errlist.append(str(err))
             verified = False
@@ -722,11 +722,11 @@ class SvnConnector(TemplateConnection):
         try:
             writeErrlist, writable, deleted = self._verify_write(path)
             errlist.extend(writeErrlist)           
-        except Exception, err:
+        except Exception as err:
             #self._mylogger.info("SvnConnector.verify_mount(): %s failed verifying write. (%s)" % (path, err))
             errlist.append(str(err))
             
         return (verified, errlist, readable, writable)
 
 if __name__ == '__main__':
-    print 'sample_conn.main(): started'
+    print('sample_conn.main(): started')


### PR DESCRIPTION
* __print()__ is a function in Python 3.
* Replace old style exceptions with new style for Python 3.

flake8 testing of https://github.com/IBM/connector-for-storediq on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./source/ftp_connector/ftp_conn.py:296:23: E999 SyntaxError: invalid syntax
                print e
                      ^
./source/svn_connector/svn_conn.py:385:25: E999 SyntaxError: invalid syntax
        except Exception, e:
                        ^
2     E999 SyntaxError: invalid syntax
2
```